### PR TITLE
Added ability to cancel animations

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -54,6 +54,8 @@ define(['TinyAnimate'], function(TinyAnimate) {
     - `duration` (int) — Duration in milliseconds
     - `easing` (string | function) — Optional: A string when the easing function is available in `TinyAnimate.easings`, or a function with the signature: `function(t, b, c, d) {...}`
     - `done` (function) — Optional: To be executed when the animation has completed.
+3. `TinyAnimate.cancel(animation)`
+    - `animation` (object) - Animation object returned from `animate` or `animateCSS`.
 
 ### Easings
 All the easings found at [easings.net](http://easings.net/) are supported. I suggest you strip out all the easings you

--- a/src/TinyAnimate.js
+++ b/src/TinyAnimate.js
@@ -9,6 +9,7 @@
  * Functions:
  *  TinyAnimate.animate(from, to, duration, update, easing, done)
  *  TinyAnimate.animateCSS(element, property, unit, from, to, duration, easing, done)
+ *  TinyAnimate.cancel(animation)
  *
  * Parameters:
  *  element   HTMLElement        A dom node
@@ -21,6 +22,9 @@
  *  easing    string | function  Optional: A string when the easing function is available in TinyAnimate.easings,
  *                                or a function with the signature: function(t, b, c, d) {...}
  *  done      function           Optional: To be executed when the animation has completed.
+ *
+ * Returns:
+ *  animation object             Animation object that can be canceled.
  */
 
 /**
@@ -71,8 +75,12 @@
         };
 
         // Animation loop
+        var canceled = false;
         var change = to - from;
         function loop(timestamp) {
+            if (canceled) {
+                return;
+            }
             var time = (timestamp || +new Date()) - start;
             update(easing(time, from, change, duration));
             if (time >= duration) {
@@ -88,6 +96,12 @@
         var start = window.performance && window.performance.now ? window.performance.now() : +new Date();
 
         rAF(loop);
+
+        return {
+            cancel: function() {
+                canceled = true;
+            }
+        };
     };
 
     /**
@@ -99,7 +113,18 @@
         var update = function(value) {
             element.style[property] = value + unit;
         };
-        exports.animate(from, to, duration, update, easing, done);
+        return exports.animate(from, to, duration, update, easing, done);
+    };
+
+    /**
+     * TinyAnimate.cancel()
+     *  Method for canceling animations
+     */
+    exports.cancel = function(animation) {
+        if(!animation) {
+            return;
+        }
+        animation.cancel();
     };
 
     /**


### PR DESCRIPTION
Returns an object from `animate` or `animateCSS` functions that has a `cancel()` function which cancels the animation. Animations can also be canceled by passing the object to the `TinyAnimate.cancel(animation)` function.